### PR TITLE
Anchor link for Introducing Web Accessibility

### DIFF
--- a/_accessibility-training/topics.md
+++ b/_accessibility-training/topics.md
@@ -69,7 +69,7 @@ This page provides material for web accessibility topics that you can use as bui
 
 {% include excol.html type="all" %}
 
-{% include_cached excol.html type="start" id="intro" %}
+{% include_cached excol.html type="start" id="introduction" %}
 
 ## 1. Introducing Web Accessibility
 


### PR DESCRIPTION
Anchor link is looking for #introduction, however id for section is #intro. Suggest to update id to `introduction` or anchor link to `intro`. I've currently updated the id.