### PR TITLE
Use default layout instead of sidenav

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,7 +51,7 @@ defaults:
     scope:
       path: "_accessibility-training"
     values:
-      layout: "sidenav"
+      layout: "default"
 
 plugins:
   - jekyll-seo-tag


### PR DESCRIPTION
This commit aims to set the `layout` default value to `default` instead of `sidenav`

That creates problems with the navigation look in Netlify previews. Example: https://deploy-preview-36--wai-develop-training.netlify.app/teach-advocate/accessibility-training/

Context:
- Currently, the `sidenav` layout is set to default for all files in the `_accessibility-training` folder
  - The `sidenav` layout does not work well with translations
  - In the `wai-website` repository, the `default` layout is the default layout for this collection since 2018, [see this commit](https://github.com/w3c/wai-website/commit/00fef1261d67cd840bc35dedf458105f65d47d14)